### PR TITLE
Updated patch for Blender v3.6.8

### DIFF
--- a/patches/patch_v3.6.8-release_FW.patch
+++ b/patches/patch_v3.6.8-release_FW.patch
@@ -1,0 +1,76 @@
+From 34ea789f8e46715f8b3ea630727feaaf6e89ae59 Mon Sep 17 00:00:00 2001
+From: jamesgray <james.gray@unsw.edu.au>
+Date: Mon, 9 Oct 2023 17:44:24 +1100
+Subject: [PATCH] applying patch manually from spring
+
+---
+ intern/cycles/kernel/geom/primitive.h | 22 ++++++++++++++--------
+ intern/cycles/scene/camera.cpp        |  4 ++++
+ 2 files changed, 18 insertions(+), 8 deletions(-)
+
+diff --git a/intern/cycles/kernel/geom/primitive.h b/intern/cycles/kernel/geom/primitive.h
+index d19fc9c015b..0356a663ef3 100644
+--- a/intern/cycles/kernel/geom/primitive.h
++++ b/intern/cycles/kernel/geom/primitive.h
+@@ -350,14 +350,20 @@ ccl_device_forceinline float4 primitive_motion_vector(KernelGlobals kg,
+   /* camera motion, for perspective/orthographic motion.pre/post will be a
+    * world-to-raster matrix, for panorama it's world-to-camera */
+   if (kernel_data.cam.type != CAMERA_PANORAMA) {
+-    ProjectionTransform projection = kernel_data.cam.worldtoraster;
+-    motion_center = transform_perspective(&projection, center);
++    // ProjectionTransform projection = kernel_data.cam.worldtoraster;
++    // motion_center = transform_perspective(&projection, center);
+ 
+-    projection = kernel_data.cam.perspective_pre;
+-    motion_pre = transform_perspective(&projection, motion_pre);
++    // projection = kernel_data.cam.perspective_pre;
++    // motion_pre = transform_perspective(&projection, motion_pre);
++    tfm = kernel_data.cam.motion_pass_pre;
++    motion_pre = transform_point(&tfm, motion_pre);
++    tfm = kernel_data.cam.worldtocamera;
++    motion_center = transform_point(&tfm, center);
+ 
+-    projection = kernel_data.cam.perspective_post;
+-    motion_post = transform_perspective(&projection, motion_post);
++    // projection = kernel_data.cam.perspective_post;
++    // motion_post = transform_perspective(&projection, motion_post);
++    tfm = kernel_data.cam.motion_pass_post;
++    motion_post = transform_point(&tfm, motion_post);
+   }
+   else {
+     tfm = kernel_data.cam.worldtocamera;
+@@ -379,10 +385,10 @@ ccl_device_forceinline float4 primitive_motion_vector(KernelGlobals kg,
+     motion_post.y *= kernel_data.cam.height;
+   }
+ 
+-  motion_pre = motion_pre - motion_center;
++  // motion_pre = motion_pre - motion_center;
+   motion_post = motion_center - motion_post;
+ 
+-  return make_float4(motion_pre.x, motion_pre.y, motion_post.x, motion_post.y);
++  return make_float4(motion_post.x, motion_post.y, motion_post.z, 0);
+ }
+ 
+ CCL_NAMESPACE_END
+diff --git a/intern/cycles/scene/camera.cpp b/intern/cycles/scene/camera.cpp
+index e53eafb8fff..b9a956ebae3 100644
+--- a/intern/cycles/scene/camera.cpp
++++ b/intern/cycles/scene/camera.cpp
+@@ -363,10 +363,14 @@ void Camera::update(Scene *scene)
+       if (have_motion) {
+         kcam->perspective_pre = cameratoraster * transform_inverse(motion[0]);
+         kcam->perspective_post = cameratoraster * transform_inverse(motion[motion.size() - 1]);
++        kcam->motion_pass_pre = transform_inverse(motion[0]);
++        kcam->motion_pass_post = transform_inverse(motion[motion.size() - 1]);
+       }
+       else {
+         kcam->perspective_pre = worldtoraster;
+         kcam->perspective_post = worldtoraster;
++        kcam->motion_pass_pre = kcam->worldtocamera;
++        kcam->motion_pass_post = kcam->worldtocamera;
+       }
+     }
+   }
+-- 
+2.33.0
+


### PR DESCRIPTION
Updated the forward patch patch file for a more recent version of blender (3.6.8). While most of the changes to each are almost identical, the file locations and line numbers have changed, because the source code of blender itself has changed.